### PR TITLE
Avoid the use of `navigator` on server side

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,8 +69,10 @@ export function* walkElementHierarchyUp(leafElement: HTMLElement): Iterable<HTML
   }
 }
 
-export const browserIsAndroid = navigator.userAgent.match(/Android/);
-export const browserIsSafari = navigator.vendor.match(/Apple/);
+export const isServer = typeof window === 'undefined';
+
+export const browserIsAndroid = isServer ? false : navigator.userAgent.match(/Android/);
+export const browserIsSafari = isServer ? false : navigator.vendor.match(/Apple/);
 export const browserIsSafariDesktop = browserIsSafari && typeof Touch === 'undefined';
 
 export function isMouseEvent(e: MouseEvent | TouchEvent): e is MouseEvent {


### PR DESCRIPTION
Pretty straightforward;

`navigator` will obviously throw an error on the server side due to not existing outside the browser. This is a simple work around.